### PR TITLE
Add graphdb calls directly where relationships are filtered

### DIFF
--- a/common/graph_db_client.py
+++ b/common/graph_db_client.py
@@ -103,13 +103,13 @@ class GraphDBClient:
                         "prop_partition_key": "entities",
                         "prop_description_embedding":json.dumps(row.description_embedding.tolist() if row.description_embedding is not None else []),
                         "prop_graph_embedding":json.dumps(row.graph_embedding.tolist() if row.graph_embedding is not None else []),
-                        "prop_text_unit_ids":json.dumps(row.text_unit_ids if row.text_unit_ids is not None else []),
+                        "prop_text_unit_ids":json.dumps(row.text_unit_ids.tolist() if row.text_unit_ids is not None else []),
                     },
                 )
             time.sleep(5)
 
 
-    def write_edges(self,data: pd.DataFrame,context_id:str="00000000-0000-0000-0000-000000000000")->None:
+    def write_edges(self,data: pd.DataFrame)->None:
         for row in data.itertuples():
             if self.element_exists("g.E()",row.id):
                 continue
@@ -134,7 +134,7 @@ class GraphDBClient:
                     "prop_source_id": row.source,
                     "prop_target_id": row.target,
                     "prop_weight": row.weight,
-                    "prop_text_unit_ids":json.dumps(row.text_unit_ids if row.text_unit_ids is not None else []),
+                    "prop_text_unit_ids":json.dumps(row.text_unit_ids.tolist() if row.text_unit_ids is not None else []),
                     "prop_description": row.description,
                     "prop_id": row.id,
                     "prop_human_readable_id": row.human_readable_id,

--- a/graphrag/index/context_switch/contextSwitcher.py
+++ b/graphrag/index/context_switch/contextSwitcher.py
@@ -222,12 +222,8 @@ class ContextSwitcher:
             if not optimized_search:
                 final_covariates = pd.concat([final_covariates, read_paraquet_file(input_storage_client, data_path + "/create_final_covariates.parquet")])
 
-            if config.graphdb.enabled:
-                final_relationships = pd.concat([final_relationships, graph_db_client.query_edges(context_id)])
-                final_entities = pd.concat([final_entities, graph_db_client.query_vertices(context_id)])
-            else:
-                final_relationships = pd.concat([final_relationships, read_paraquet_file(input_storage_client, data_path + "/create_final_relationships.parquet")])
-                final_entities = pd.concat([final_entities, read_paraquet_file(input_storage_client, data_path + "/create_final_entities.parquet")])
+            final_relationships = pd.concat([final_relationships, read_paraquet_file(input_storage_client, data_path + "/create_final_relationships.parquet")])
+            final_entities = pd.concat([final_entities, read_paraquet_file(input_storage_client, data_path + "/create_final_entities.parquet")])
 
 
             vector_store_args = (
@@ -250,6 +246,10 @@ class ContextSwitcher:
             description_embedding_store.load_entities(entities)
             if self.use_kusto_community_reports:
                 description_embedding_store.load_reports(reports)
+        
+        if config.graphdb.enabled:
+            graph_db_client.write_vertices(final_entities)
+            graph_db_client.write_edges(final_relationships)
 
     def deactivate(self):
         """DeActivate the context."""

--- a/graphrag/query/cli.py
+++ b/graphrag/query/cli.py
@@ -201,13 +201,11 @@ def run_local_search(
             final_covariates = pd.concat([final_covariates, read_paraquet_file(input_storage_client, data_path + "/create_final_covariates.parquet")])
 
         if config.graphdb.enabled:
-            final_relationships = pd.concat([final_relationships, graph_db_client.query_edges(context_id)])
             final_entities = pd.concat([final_entities, graph_db_client.query_vertices(context_id)])
         else:
-            final_relationships = pd.concat([final_relationships, read_paraquet_file(input_storage_client, data_path + "/create_final_relationships.parquet")])
             final_entities = pd.concat([final_entities, read_paraquet_file(input_storage_client, data_path + "/create_final_entities.parquet")])
 
-
+    graph_db_client._client.close()
     vector_store_args = (
         config.embeddings.vector_store if config.embeddings.vector_store else {}
     )
@@ -242,12 +240,14 @@ def run_local_search(
         reports=reports,
         text_units=read_indexer_text_units(final_text_units),
         entities=entities,
-        relationships=read_indexer_relationships(final_relationships),
+        relationships=[],
         covariates={"claims": covariates},
         description_embedding_store=description_embedding_store,
         response_type=response_type,
+        context_id=context_id,
         is_optimized_search=optimized_search,
         use_kusto_community_reports=use_kusto_community_reports,
+        graphdb_config=config.graphdb,
     )
 
     if optimized_search:

--- a/graphrag/query/context_builder/local_context.py
+++ b/graphrag/query/context_builder/local_context.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from typing import Any, cast
 
 import pandas as pd
+from common.graph_db_client import GraphDBClient
 import tiktoken
 
 from graphrag.model import Covariate, Entity, Relationship
@@ -164,7 +165,8 @@ def build_relationship_context(
     relationship_ranking_attribute: str = "rank",
     column_delimiter: str = "|",
     context_name: str = "Relationships",
-    is_optimized_search: bool = False
+    is_optimized_search: bool = False,
+    graphdb_client: GraphDBClient|None=None,
 ) -> tuple[str, pd.DataFrame]:
     """Prepare relationship data tables as context data for system prompt."""
     selected_relationships = _filter_relationships(
@@ -172,6 +174,7 @@ def build_relationship_context(
         relationships=relationships,
         top_k_relationships=top_k_relationships,
         relationship_ranking_attribute=relationship_ranking_attribute,
+        graphdb_client=graphdb_client,
     )
 
     if len(selected_entities) == 0 or len(selected_relationships) == 0:
@@ -236,6 +239,7 @@ def _filter_relationships(
     relationships: list[Relationship],
     top_k_relationships: int = 10,
     relationship_ranking_attribute: str = "rank",
+    graphdb_client: GraphDBClient|None=None,
 ) -> list[Relationship]:
     """Filter and sort relationships based on a set of selected entities and a ranking attribute."""
     # First priority: in-network relationships (i.e. relationships between selected entities)
@@ -243,6 +247,7 @@ def _filter_relationships(
         selected_entities=selected_entities,
         relationships=relationships,
         ranking_attribute=relationship_ranking_attribute,
+        graphdb_client=graphdb_client,
     )
 
     # Second priority -  out-of-network relationships
@@ -251,6 +256,7 @@ def _filter_relationships(
         selected_entities=selected_entities,
         relationships=relationships,
         ranking_attribute=relationship_ranking_attribute,
+        graphdb_client=graphdb_client,
     )
     if len(out_network_relationships) <= 1:
         return in_network_relationships + out_network_relationships

--- a/graphrag/query/factories.py
+++ b/graphrag/query/factories.py
@@ -3,6 +3,7 @@
 
 """Query Factory methods to support CLI."""
 
+from graphrag.config.models.graphdb_config import GraphDBConfig
 import tiktoken
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
@@ -108,8 +109,10 @@ def get_local_search_engine(
     covariates: dict[str, list[Covariate]],
     response_type: str,
     description_embedding_store: BaseVectorStore,
+    context_id: str,
     is_optimized_search: bool = False,
     use_kusto_community_reports: bool = False,
+    graphdb_config: GraphDBConfig|None = None,
 ) -> LocalSearch:
     """Create a local search engine based on data + configuration."""
     llm = get_llm(config)
@@ -132,6 +135,8 @@ def get_local_search_engine(
             token_encoder=token_encoder,
             is_optimized_search= is_optimized_search,
             use_kusto_community_reports=use_kusto_community_reports,
+            graphdb_config=graphdb_config,
+            context_id=context_id,
         ),
         token_encoder=token_encoder,
         llm_params={


### PR DESCRIPTION
<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

Querying selected edges from the graph directly from graphdb instead of querying all the edges and filtering them later. Moved writing into graphdb to the activation workflow

## Related Issues

Previously all the edges were loaded from graphdb and then filtered

## Proposed Changes

Inside the filter_relationships function, we now query the selected relationships directly from the graph. Also, writing into the graphdb now happens at context activation time

## Checklist

- [ ] I have tested these changes locally.
- [ ] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).
